### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/kevinlin/cowork-z/security/code-scanning/1](https://github.com/kevinlin/cowork-z/security/code-scanning/1)

In general, this issue is fixed by adding an explicit `permissions` block to the workflow (either at the top level, applying to all jobs, or within the specific job) that grants only the minimal access required by the steps. For a build-and-test workflow that only reads repository contents and does not write to the repo, issues, or pull requests, `contents: read` is usually sufficient.

The best fix here, without altering existing functionality, is to add a top-level `permissions` block right under the workflow `name:` (before `on:`), setting `contents: read`. This will apply to all jobs in the workflow (currently just `test`) and ensures the `GITHUB_TOKEN` has read-only access to repository contents. No steps in the snippet perform write operations using the token, so this change should not break anything while satisfying the CodeQL requirement and enforcing least privilege.

Concretely, in `.github/workflows/test.yml`, insert:

```yml
permissions:
  contents: read
```

after line 1 (`name: Build`) and before the `on:` block. No imports or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
