### PR TITLE
Potential fix for code scanning alert no. 3: Inefficient regular expression

### DIFF
--- a/src/lib/content-enrichment.ts
+++ b/src/lib/content-enrichment.ts
@@ -165,7 +165,7 @@ export function enrichContentWithLinks(markdown: string): string {
   }
 
   // 3. Windows paths: C:\dir\file.ext or D:/dir/file.ext
-  const winPathRe = /[A-Za-z]:[/\\](?:[^\s<>)\]*]+[/\\])*[^\s<>)\]*]+\.\w+/g;
+  const winPathRe = /[A-Za-z]:[\\/](?:[^\\/\s<>)]+[\\/])*[^\\/\s<>)]+\.\w+/g;
   while ((m = winPathRe.exec(markdown)) !== null) {
     const start = m.index;
     const candidate = m[0];


### PR DESCRIPTION
Potential fix for [https://github.com/kevinlin/cowork-z/security/code-scanning/3](https://github.com/kevinlin/cowork-z/security/code-scanning/3)

In general, to fix inefficient regular expressions you remove ambiguous nested quantifiers, especially combinations like `(something+)*` or `(?:.+)+` where the inner part can match the same substring in multiple ways. You often do this by making the repeated unit more specific (e.g., exclude certain characters), by flattening structure (avoid repeated groups-of-repetitions), or by anchoring and limiting repetition to a safe range.

In this specific case, the Windows-path regex:

```ts
const winPathRe = /[A-Za-z]:[/\\](?:[^\s<>)\]*]+[/\\])*[^\s<>)\]*]+\.\w+/g;
```

is trying to match:

- A drive letter and colon: `[A-Za-z]:`
- A separator: `[/\\]`
- Zero or more directory segments ending with a separator: `(?:...[/\\])*`
- A final file name segment: `...[...]`
- A file extension: `\.\w+`

The problematic subpattern `[^\s<>)\]*]+` is overly complex and appears twice within quantified contexts. We can safely replace this with a simpler, unambiguous “path segment” pattern that excludes whitespace and terminators (`<`, `>`, `)`) and the two separators `\` and `/`. That dramatically reduces backtracking potential while preserving intent.

A robust replacement is to define a path segment as:

```regex
[^\\/\s<>)]+
```

Then the whole regex becomes:

```regex
[A-Za-z]:[\\/](?:[^\\/\s<>)]+[\\/])*[^\\/\s<>)]+\.\w+
```

This keeps the same semantics (drive, separators, segments without spaces or angle brackets, extension) but removes the ambiguous nested repetition and the suspicious `\]*` sequence. The change is local to the single `winPathRe` definition on line 168; no new imports or helpers are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
