### PR TITLE
fix: override @isaacs/brace-expansion to patched version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,10 @@
     "ultracite": "7.1.3",
     "vite": "^7.0.4",
     "vitest": "^4.0.18"
+  },
+  "pnpm": {
+    "overrides": {
+      "@isaacs/brace-expansion": "5.0.1"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@isaacs/brace-expansion': 5.0.1
+
 importers:
 
   .:
@@ -556,8 +559,8 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -3034,7 +3037,7 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
+  '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
@@ -4707,7 +4710,7 @@ snapshots:
 
   minimatch@10.1.1:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minipass@7.1.2: {}
 


### PR DESCRIPTION
### Motivation
- Resolve a Dependabot/security alert by ensuring the vulnerable transitive package `@isaacs/brace-expansion` is pinned to the patched `5.0.1` release.

### Description
- Add a `pnpm.overrides` entry to `package.json` to force `@isaacs/brace-expansion` -> `5.0.1` and regenerate `pnpm-lock.yaml` so all `minimatch` paths and lockfile snapshots resolve to the patched version.

### Testing
- Ran `pnpm install` and `pnpm audit --json`, which no longer reports the `@isaacs/brace-expansion` advisory, ran `pnpm typecheck` (`tsc --noEmit`) which passed, and attempted `cd src-tauri && cargo check` which could not complete in this environment due to a missing system library (`glib-2.0.pc`) required by `glib-sys`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb9388f0c8331a397ab360c25625a)