### PR TITLE
fix: add About button to sidebar for discoverability

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AnimatePresence, motion } from 'framer-motion';
-import { FolderTree, MessageSquare, MessageSquarePlus, Search, Settings } from 'lucide-react';
+import { FolderTree, Info, MessageSquare, MessageSquarePlus, Search, Settings } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import FileTreePanel from '@/components/sidebar/FileTreePanel';
@@ -33,7 +33,7 @@ type SidebarTab = 'sessions' | 'files';
 
 export default function Sidebar() {
   const navigate = useNavigate();
-  const { tasks, loadTasks, updateTaskStatus, addTaskUpdate, openLauncher, setShowSettings } = useTaskStore();
+  const { tasks, loadTasks, updateTaskStatus, addTaskUpdate, openLauncher, setShowSettings, setShowAbout } = useTaskStore();
   const api = getTauriAPI();
   const currentTaskTodos = useTaskStore((s) => s.todos.get(s.currentTask?.id ?? '') ?? EMPTY_TODOS);
   const hasTodos = currentTaskTodos.length > 0;
@@ -254,9 +254,18 @@ export default function Sidebar() {
             <img alt="Openwork" src={logoImage} style={{ height: '20px', paddingLeft: '6px' }} />
           </div>
 
-          {/* Feedback & Settings - Bottom Right */}
+          {/* Feedback, About & Settings - Bottom Right */}
           <div className="flex items-center gap-1">
             <FeedbackButton />
+            <Button
+              data-testid="sidebar-about-button"
+              onClick={() => setShowAbout(true)}
+              size="icon"
+              title="About Cowork-Z"
+              variant="ghost"
+            >
+              <Info className="h-4 w-4" />
+            </Button>
             <Button
               data-testid="sidebar-settings-button"
               onClick={() => {


### PR DESCRIPTION
The About dialog existed but was only accessible via the native OS menu (Help > About Cowork-Z), making it invisible to users who don't explore the menu bar.

This adds an Info icon button to the sidebar bottom bar alongside Feedback and Settings, giving users a clear in-app entry point to open the About dialog on all platforms.

Fixes #18

Generated with [Claude Code](https://claude.ai/code)