### PR TITLE
fix: autoscroll to bottom when sending a follow-up message

### DIFF
--- a/UPDATE_LOG.md
+++ b/UPDATE_LOG.md
@@ -4,7 +4,7 @@
 
 ## v0.8.3
 
-- 
+- **Fix: Chat does not autoscroll when sending a follow-up after scrolling up** — When a user scrolled up to re-read earlier messages and then sent a follow-up, the chat stayed at the scrolled position instead of snapping to the bottom; the streaming autoscroll effect was also suppressed because the scroll position was no longer at the bottom. All three send paths (follow-up message, continue, and post-API-key-save pending follow-up) now immediately reset the scroll position to the bottom before streaming begins.
 
 ## v0.8.2 (2026-06-27)
 

--- a/src/pages/Execution.tsx
+++ b/src/pages/Execution.tsx
@@ -92,6 +92,17 @@ export default function ExecutionPage() {
     setIsAtBottom(atBottom);
   }, []);
 
+  // Re-enable autoscroll and snap to bottom immediately (e.g. after sending a follow-up)
+  const scrollToBottomNow = useCallback(() => {
+    setIsAtBottom(true);
+    requestAnimationFrame(() => {
+      const container = scrollContainerRef.current;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
+    });
+  }, []);
+
   // Load debug mode setting on mount and subscribe to changes
   useEffect(() => {
     api.getDebugMode().then(setDebugModeEnabled).catch(console.error);
@@ -266,6 +277,7 @@ export default function ExecutionPage() {
       }
     }
     await sendFollowUp(message);
+    scrollToBottomNow();
   };
 
   const handleContinue = async () => {
@@ -279,6 +291,7 @@ export default function ExecutionPage() {
       }
     }
     await sendFollowUp('continue');
+    scrollToBottomNow();
   };
 
   // Chat-scoped keyboard shortcuts
@@ -310,6 +323,7 @@ export default function ExecutionPage() {
     if (pendingFollowUp) {
       await sendFollowUp(pendingFollowUp);
       setPendingFollowUp(null);
+      scrollToBottomNow();
     }
   };
 


### PR DESCRIPTION
When a user scrolls up to re-read messages and then sends a follow-up, isAtBottom is false so the streaming autoscroll effect never fires. Added scrollToBottomNow() which resets isAtBottom and immediately snaps the container to the bottom, applied to all three send paths: follow-up, continue, and post-API-key-save pending follow-up.

Fixes #24